### PR TITLE
fix: use manual flags for sending and previewing emails

### DIFF
--- a/dev/dev-docker-image/base.json5
+++ b/dev/dev-docker-image/base.json5
@@ -12,11 +12,12 @@
   },
   emailer: {
     mode: "SES",
-    templateRootPath: "/a/emails",
     from: {
       name: "Elsa Data",
       address: "no-reply@umccr.org",
     },
+    sendEmails: true,
+    previewEmails: false,
   },
   // datasetEgress: {
   //  updateInterval: "0 6 * * *", // 6am

--- a/dev/dev-docker-image/base.json5
+++ b/dev/dev-docker-image/base.json5
@@ -12,6 +12,7 @@
   },
   emailer: {
     mode: "SES",
+    templateRootPath: "/a/emails",
     from: {
       name: "Elsa Data",
       address: "no-reply@umccr.org",


### PR DESCRIPTION
Fixes emails not sending properly, related to https://github.com/elsa-data/elsa-data/pull/484.

### Changes
* Specify `sendEmails` and `previewEmails` flags manually.